### PR TITLE
Sharness support and tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+# dist: trusty # KVM Setup
+
+# For now only "linux" as it looks like docker
+# is not available on "osx"
+os:
+  - linux
+
+language: go
+
+go:
+    - 1.5.2
+
+script:
+  - cd sharness
+  - make
+
+# For docker containers
+
+sudo: required
+
+services:
+  - docker

--- a/sharness/.gitignore
+++ b/sharness/.gitignore
@@ -1,0 +1,3 @@
+lib/sharness/
+test-results/
+trash directory.*.sh/

--- a/sharness/.gitignore
+++ b/sharness/.gitignore
@@ -1,3 +1,5 @@
 lib/sharness/
 test-results/
 trash directory.*.sh/
+bin/ipfs-update
+BUILD-OPTIONS

--- a/sharness/Makefile
+++ b/sharness/Makefile
@@ -1,0 +1,67 @@
+# Run sharness tests
+#
+# Copyright (c) 2014 Christian Couder
+# MIT Licensed; see the LICENSE file in this repository.
+#
+# NOTE: run with TEST_VERBOSE=1 for verbose sharness tests.
+
+T = $(sort $(wildcard t[0-9][0-9][0-9][0-9]-*.sh))
+LIBDIR = lib
+SHARNESSDIR = sharness
+AGGREGATE = $(LIBDIR)/$(SHARNESSDIR)/aggregate-results.sh
+
+
+# Add below the binaries that this project generates or needs.
+# For example:
+# BINS = bin/ipfs
+BINS =
+
+all: aggregate
+
+clean: clean-test-results
+	@echo "*** $@ ***"
+	# Clean binaries below.
+	# For example:
+	# -rm -rf bin/ipfs
+
+clean-test-results:
+	@echo "*** $@ ***"
+	-rm -rf test-results
+
+$(T): clean-test-results deps
+	@echo "*** $@ ***"
+	./$@
+
+aggregate: clean-test-results $(T)
+	@echo "*** $@ ***"
+	ls test-results/t*-*.sh.*.counts | $(AGGREGATE)
+
+# Add below some needed dependencies.
+# For example:
+# deps: sharness $(BINS) curl
+deps: sharness $(BINS)
+
+sharness:
+	@echo "*** checking $@ ***"
+	lib/install-sharness.sh
+
+# Add below other targets like:
+# - the targets needed to build binaries,
+# - targets using special compile flags,
+# - targets to check or install dependencies.
+#
+# For example:
+#
+# GOFLAGS =
+#
+# bin/%: FORCE
+# 	cd .. && make GOFLAGS=$(GOFLAGS) $@
+#
+# race:
+# 	make GOFLAGS=-race all
+#
+# curl:
+#	@which curl >/dev/null || (echo "Please install curl!" && false)
+
+.PHONY: all clean clean-test-results $(T) aggregate deps sharness FORCE
+

--- a/sharness/Makefile
+++ b/sharness/Makefile
@@ -10,19 +10,20 @@ LIBDIR = lib
 SHARNESSDIR = sharness
 AGGREGATE = $(LIBDIR)/$(SHARNESSDIR)/aggregate-results.sh
 
+# Binaries generated
+BINS = bin/ipfs-update
 
-# Add below the binaries that this project generates or needs.
-# For example:
-# BINS = bin/ipfs
-BINS =
+# Source files location
+IPFS_UPDATE_SRC = ../
+
+# User might want to override those on the command line
+GOFLAGS =
 
 all: aggregate
 
 clean: clean-test-results
 	@echo "*** $@ ***"
-	# Clean binaries below.
-	# For example:
-	# -rm -rf bin/ipfs
+	-rm -rf $(BINS)
 
 clean-test-results:
 	@echo "*** $@ ***"
@@ -36,32 +37,21 @@ aggregate: clean-test-results $(T)
 	@echo "*** $@ ***"
 	ls test-results/t*-*.sh.*.counts | $(AGGREGATE)
 
-# Add below some needed dependencies.
-# For example:
-# deps: sharness $(BINS) curl
+# Needed dependencies.
 deps: sharness $(BINS)
 
 sharness:
 	@echo "*** checking $@ ***"
 	lib/install-sharness.sh
 
-# Add below other targets like:
-# - the targets needed to build binaries,
-# - targets using special compile flags,
-# - targets to check or install dependencies.
-#
-# For example:
-#
-# GOFLAGS =
-#
-# bin/%: FORCE
-# 	cd .. && make GOFLAGS=$(GOFLAGS) $@
-#
-# race:
-# 	make GOFLAGS=-race all
-#
-# curl:
-#	@which curl >/dev/null || (echo "Please install curl!" && false)
+find_go_files = $(shell find $(1) -name "*.go")
+
+bin/ipfs-update: $(call find_go_files, $(IPFS_UPDATE_SRC)) BUILD-OPTIONS
+	@echo "*** installing $@ ***"
+	go build $(GOFLAGS) -o $@ $(IPFS_UPDATE_SRC)
+
+BUILD-OPTIONS: FORCE
+	@bin/checkflags '$@' '$(GOFLAGS)' '*** new Go flags ***'
 
 .PHONY: all clean clean-test-results $(T) aggregate deps sharness FORCE
 

--- a/sharness/bin/checkflags
+++ b/sharness/bin/checkflags
@@ -1,0 +1,25 @@
+#!/bin/sh
+# Author: Christian Couder <chriscool@tuxfamily.org>
+# MIT LICENSED
+
+if test "$#" -lt 3
+then
+    echo >&2 "usage $0 FILE VALUES MSG..."
+    exit 1
+fi
+
+FLAG_FILE="$1"
+FLAG_VALS="$2"
+shift
+shift
+FLAG_MSGS="$@"
+
+test -f $FLAG_FILE || touch $FLAG_FILE
+
+# Use x in front of tested values as flags could be
+# interpreted by "test" to be for itself.
+if test x"$FLAG_VALS" != x"$(cat "$FLAG_FILE")"
+then
+    echo "$FLAG_MSGS"
+    echo "$FLAG_VALS" >"$FLAG_FILE"
+fi

--- a/sharness/lib/install-sharness.sh
+++ b/sharness/lib/install-sharness.sh
@@ -1,0 +1,60 @@
+#!/bin/sh
+# install-sharness.sh
+#
+# Copyright (c) 2014 Juan Batiz-Benet
+# Copyright (c) 2015 Christian Couder
+# MIT Licensed; see the LICENSE file in this repository.
+#
+# This script checks that Sharness is installed in:
+#
+# $(pwd)/$clonedir/$sharnessdir/
+#
+# where $clonedir and $sharnessdir are configured below.
+#
+# If Sharness is not installed, this script will clone it
+# from $urlprefix (defined below).
+#
+# If Sharness is not uptodate with $version (defined below),
+# this script will fetch and will update the installed
+# version to $version.
+#
+
+# settings
+version=35e1480425c022cb964b614621bdcd21ceaf2e94
+urlprefix=https://github.com/mlafeldt/sharness.git
+clonedir=lib
+sharnessdir=sharness
+
+if test -f "$clonedir/$sharnessdir/SHARNESS_VERSION_$version"
+then
+    # There is the right version file. Great, we are done!
+    exit 0
+fi
+
+die() {
+    echo >&2 "$@"
+    exit 1
+}
+
+checkout_version() {
+    git checkout "$version" || die "Could not checkout '$version'"
+    rm -f SHARNESS_VERSION_* || die "Could not remove 'SHARNESS_VERSION_*'"
+    touch "SHARNESS_VERSION_$version" || die "Could not create 'SHARNESS_VERSION_$version'"
+    echo "Sharness version $version is checked out!"
+}
+
+if test -d "$clonedir/$sharnessdir/.git"
+then
+    # We need to update sharness!
+    cd "$clonedir/$sharnessdir" || die "Could not cd into '$clonedir/$sharnessdir' directory"
+    git fetch || die "Could not fetch to update sharness"
+else
+    # We need to clone sharness!
+    mkdir -p "$clonedir" || die "Could not create '$clonedir' directory"
+    cd "$clonedir" || die "Could not cd into '$clonedir' directory"
+
+    git clone "$urlprefix" || die "Could not clone '$urlprefix'"
+    cd "$sharnessdir" || die "Could not cd into '$sharnessdir' directory"
+fi
+
+checkout_version

--- a/sharness/lib/test-lib.sh
+++ b/sharness/lib/test-lib.sh
@@ -1,0 +1,39 @@
+# Test framework for ipfs-update
+#
+# Copyright (c) 2015 Christian Couder
+# MIT Licensed; see the LICENSE file in this repository.
+#
+# We are using Sharness (https://github.com/mlafeldt/sharness)
+# which was extracted from the Git test framework.
+
+SHARNESS_LIB="lib/sharness/sharness.sh"
+
+. "$SHARNESS_LIB" || {
+	echo >&2 "Cannot source: $SHARNESS_LIB"
+	echo >&2 "Please check Sharness installation."
+	exit 1
+}
+
+# Please put ipfs-update specific shell functions and variables below
+
+DEFAULT_DOCKER_IMG="debian"
+DOCKER_IMG="$DEFAULT_DOCKER_IMG"
+
+TEST_TRASH_DIR=$(pwd)
+TEST_SCRIPTS_DIR=$(dirname "$TEST_TRASH_DIR")
+APP_ROOT_DIR=$(dirname "$TEST_SCRIPTS_DIR")
+
+# This writes a docker ID on stdout
+start_docker() {
+	docker run -it -d -v "$APP_ROOT_DIR:/mnt" -w "/mnt" "$DOCKER_IMG" /bin/bash
+}
+
+# This takes a docker ID and a command as arguments
+exec_docker() {
+	docker exec -i "$1" /bin/bash -c "$2"
+}
+
+# This takes a docker ID as argument
+stop_docker() {
+	docker stop "$1"
+}

--- a/sharness/lib/test-lib.sh
+++ b/sharness/lib/test-lib.sh
@@ -23,9 +23,11 @@ TEST_TRASH_DIR=$(pwd)
 TEST_SCRIPTS_DIR=$(dirname "$TEST_TRASH_DIR")
 APP_ROOT_DIR=$(dirname "$TEST_SCRIPTS_DIR")
 
+CERTIFS='/etc/ssl/certs/ca-certificates.crt:/etc/ssl/certs/ca-certificates.crt'
+
 # This writes a docker ID on stdout
 start_docker() {
-	docker run -it -d -v "$APP_ROOT_DIR:/mnt" -w "/mnt" "$DOCKER_IMG" /bin/bash
+	docker run -it -d -v "$CERTIFS" -v "$APP_ROOT_DIR:/mnt" -w "/mnt" "$DOCKER_IMG" /bin/bash
 }
 
 # This takes a docker ID and a command as arguments

--- a/sharness/t0000-sharness.sh
+++ b/sharness/t0000-sharness.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+test_description="Show basic features of Sharness"
+
+. ./lib/sharness/sharness.sh
+
+test_expect_success "Success is reported like this" "
+    echo hello world | grep hello
+"
+
+test_expect_success "Commands are chained this way" "
+    test x = 'x' &&
+    test 2 -gt 1 &&
+    echo success
+"
+
+return_42() {
+    echo "Will return soon"
+    return 42
+}
+
+test_expect_success "You can test for a specific exit code" "
+    test_expect_code 42 return_42
+"
+
+test_expect_failure "We expect this to fail" "
+    test 1 = 2
+"
+
+test_done
+
+# vi: set ft=sh :

--- a/sharness/t0000-sharness.sh
+++ b/sharness/t0000-sharness.sh
@@ -2,7 +2,7 @@
 
 test_description="Show basic features of Sharness"
 
-. ./lib/sharness/sharness.sh
+. lib/test-lib.sh
 
 test_expect_success "Success is reported like this" "
     echo hello world | grep hello

--- a/sharness/t0010-docker.sh
+++ b/sharness/t0010-docker.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+test_description="Basic Docker Tests"
+
+. lib/test-lib.sh
+
+test_expect_success "docker is installed" '
+	type docker
+'
+
+test_expect_success "'docker --version' works" '
+	docker --version >actual
+'
+
+test_expect_success "'docker --version' output looks good" '
+	egrep "^Docker version" actual
+'
+
+test_expect_success "current user is in the 'docker' group" '
+	groups | egrep "\bdocker\b"
+'
+
+test_expect_success "start a docker container" '
+	DOCID=$(start_docker)
+'
+
+test_expect_success "exec a command in docker container" '
+	exec_docker "$DOCID" "echo \"Hello world!\"" >actual
+'
+
+test_expect_success "command output looks good" '
+	echo "Hello world!" >expected &&
+	test_cmp expected actual
+'
+
+test_expect_success "stop a docker container" '
+	stop_docker "$DOCID"
+'
+
+test_done

--- a/sharness/t0020-version.sh
+++ b/sharness/t0020-version.sh
@@ -1,24 +1,51 @@
 #!/bin/sh
 
-test_description="ipfs-update version"
+test_description="ipfs-update version and versions"
 
 . lib/test-lib.sh
+
+LOCAL_IPFS_UPDATE="../bin/ipfs-update"
+GUEST_IPFS_UPDATE="sharness/bin/ipfs-update"
+
+test_expect_success "ipfs-update binary is here" '
+	test -f "$LOCAL_IPFS_UPDATE"
+'
+
+test_expect_success "'ipfs-update versions' works" '
+	"$LOCAL_IPFS_UPDATE" versions >actual
+'
+
+test_expect_success "'ipfs-update versions' output looks good" '
+	grep v0.3.7 actual &&
+	grep v0.3.8 actual &&
+	grep v0.3.9 actual
+'
 
 test_expect_success "start a docker container" '
 	DOCID=$(start_docker)
 '
 
-test_expect_success "ipfs-update binary is there" '
-	exec_docker "$DOCID" "test -f sharness/bin/ipfs-update"
+test_expect_success "ipfs-update binary is on the container" '
+	exec_docker "$DOCID" "test -f $GUEST_IPFS_UPDATE"
 '
 
 test_expect_success "'ipfs-update version' works" '
-	exec_docker "$DOCID" "sharness/bin/ipfs-update version" >actual
+	exec_docker "$DOCID" "$GUEST_IPFS_UPDATE version" >actual
 '
 
 test_expect_success "'ipfs-update version' output looks good" '
 	echo "none" >expected &&
 	test_cmp expected actual
+'
+
+test_expect_success "'ipfs-update versions' works" '
+	exec_docker "$DOCID" "$GUEST_IPFS_UPDATE versions" >actual
+'
+
+test_expect_success "'ipfs-update versions' output looks good" '
+	grep v0.3.7 actual &&
+	grep v0.3.8 actual &&
+	grep v0.3.9 actual
 '
 
 test_expect_success "stop a docker container" '

--- a/sharness/t0020-version.sh
+++ b/sharness/t0020-version.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+test_description="ipfs-update version"
+
+. lib/test-lib.sh
+
+test_expect_success "start a docker container" '
+	DOCID=$(start_docker)
+'
+
+test_expect_success "ipfs-update binary is there" '
+	exec_docker "$DOCID" "test -f sharness/bin/ipfs-update"
+'
+
+test_expect_success "'ipfs-update version' works" '
+	exec_docker "$DOCID" "sharness/bin/ipfs-update version" >actual
+'
+
+test_expect_success "'ipfs-update version' output looks good" '
+	echo "none" >expected &&
+	test_cmp expected actual
+'
+
+test_expect_success "stop a docker container" '
+	stop_docker "$DOCID"
+'
+
+test_done

--- a/sharness/t0030-install.sh
+++ b/sharness/t0030-install.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+
+test_description="ipfs-update install"
+
+. lib/test-lib.sh
+
+GUEST_IPFS_UPDATE="sharness/bin/ipfs-update"
+
+test_expect_success "start a docker container" '
+	DOCID=$(start_docker)
+'
+
+test_expect_success "'ipfs-update install' works" '
+	exec_docker "$DOCID" "$GUEST_IPFS_UPDATE install v0.3.9" >actual
+'
+
+test_expect_success "'ipfs-update install' output looks good" '
+	grep "installing ipfs version v0.3.9" actual
+'
+
+test_expect_success "'ipfs-update version' works" '
+	exec_docker "$DOCID" "$GUEST_IPFS_UPDATE version" >actual
+'
+
+test_expect_success "'ipfs-update version' output looks good" '
+	echo "v0.3.9" >expected &&
+	test_cmp expected actual
+'
+
+test_expect_success "stop a docker container" '
+	stop_docker "$DOCID"
+'
+
+test_done


### PR DESCRIPTION
This adds sharness support to test ipfs-update and then tests to test it.

For now only the following commands are tested:

- ipfs-update version
- ipfs-update versions
- ipfs-update install

but should not be very difficult to add tests for the rest:

- ipfs-update revert
- ipfs-update fetch

This uses docker so that ipfs-update installs ipfs on a docker container, to avoid polluting the machine running the tests.
