### PR TITLE
Use specific user agent

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1,0 +1,14 @@
+package config
+
+// CurrentAppName is the name of this application
+const CurrentAppName = "ipfs-update"
+
+// CurrentVersionNumber is the current application's version literal
+const CurrentVersionNumber = "0.1.0"
+
+// CurrentCommit is the current git commit, if it is available.
+// It might not be currently available, but it might be later if we
+// add a Makefile and set it as a ldflag in the Makefile.
+var CurrentCommit string
+
+

--- a/config/config.go
+++ b/config/config.go
@@ -11,4 +11,13 @@ const CurrentVersionNumber = "0.1.0"
 // add a Makefile and set it as a ldflag in the Makefile.
 var CurrentCommit string
 
+func GetUserAgent() string {
+	ua := CurrentAppName + "/" + CurrentVersionNumber
+
+	if CurrentCommit != "" {
+		ua += "-" + CurrentCommit
+	}
+
+	return ua
+}
 

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	cli "github.com/codegangsta/cli"
+	config "github.com/ipfs/ipfs-update/config"
 	util "github.com/ipfs/ipfs-update/util"
 	stump "github.com/whyrusleeping/stump"
 )
@@ -19,7 +20,7 @@ func init() {
 func main() {
 	app := cli.NewApp()
 	app.Usage = "update ipfs"
-	app.Version = "0.1.0"
+	app.Version = config.CurrentVersionNumber
 
 	app.Flags = []cli.Flag{
 		cli.BoolFlag{

--- a/util/utils.go
+++ b/util/utils.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	api "github.com/ipfs/go-ipfs-api"
+	config "github.com/ipfs/ipfs-update/config"
 	stump "github.com/whyrusleeping/stump"
 )
 
@@ -39,11 +40,27 @@ func ApiEndpoint(ipfspath string) (string, error) {
 	return parts[2] + ":" + parts[4], nil
 }
 
+func httpGet(url string) (*http.Response, error) {
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("http.NewRequest error: %s", err)
+	}
+
+	req.Header.Set("User-Agent", config.GetUserAgent())
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("http.DefaultClient.Do error: %s", err)
+	}
+
+	return resp, nil
+}
+
 func httpFetch(url string) (io.ReadCloser, error) {
 	stump.VLog("fetching url: %s", url)
-	resp, err := http.Get(url)
+	resp, err := httpGet(url)
 	if err != nil {
-		return nil, fmt.Errorf("http.Get error: %s", err)
+		return nil, err
 	}
 
 	if resp.StatusCode >= 400 {


### PR DESCRIPTION
@lgierth suggested "all our little tools identified themselves with a User-Agent header" in https://github.com/ipfs/fs-repo-migrations/pull/25 and I think it's a very good idea.