### PR TITLE
Fix install when GOPATH has the form "path1:path2"

### DIFF
--- a/install.go
+++ b/install.go
@@ -287,28 +287,42 @@ func (i *Install) SelectGoodInstallLoc() error {
 var errNoGoodInstall = fmt.Errorf("could not find good install location")
 
 func findGoodInstallDir() (string, error) {
-	// gopath setup?
-	gopath := os.Getenv("GOPATH")
-	if gopath != "" {
-		return filepath.Join(gopath, "bin"), nil
+	// Gather some candidate locations
+	// The first ones have more priority than the last ones
+	var candidates []string
+
+	// First candidate GOBIN
+	gobin := os.Getenv("GOBIN")
+	if gobin != "" {
+		candidates = append(candidates, gobin)
 	}
 
-	common := []string{"/usr/local/bin"}
-	for _, dir := range common {
+	// Second candidates, GOPATH(s)/bin
+	gopath := os.Getenv("GOPATH")
+	if gopath != "" {
+		gopaths := strings.Split(gopath, ":")
+		for i, _ := range gopaths {
+			gopaths[i] = filepath.Join(gopaths[i], "bin")
+		}
+		candidates = append(candidates, gopaths...)
+	}
+
+	candidates = append(candidates, "/usr/local/bin")
+
+	// Let's try user's $HOME/bin too
+	if home := os.Getenv("HOME"); home != "" {
+		homebin := filepath.Join(home, "bin")
+		candidates = append(candidates, homebin)
+	}
+
+	// Finally /usr/bin
+	candidates = append(candidates, "/usr/bin")
+
+	// Test if it makes sense to install to any of those
+	for _, dir := range candidates {
 		if canWrite(dir) && isInPath(dir) {
 			return dir, nil
 		}
-	}
-
-	// hrm, none of those worked. lets check home.
-	home := os.Getenv("HOME")
-	if home == "" {
-		return "", errNoGoodInstall
-	}
-
-	homebin := filepath.Join(home, "bin")
-	if canWrite(homebin) {
-		return homebin, nil
 	}
 
 	return "", errNoGoodInstall

--- a/install.go
+++ b/install.go
@@ -310,14 +310,14 @@ func findGoodInstallDir() (string, error) {
 	candidates = append(candidates, "/usr/local/bin")
 
 	// Let's try user's $HOME/bin too
-	if home := os.Getenv("HOME"); home != "" {
+	// but not root because no one installs to /root/bin
+	if home := os.Getenv("HOME"); home != "" && os.Getenv("USER") != "root" {
 		homebin := filepath.Join(home, "bin")
 		candidates = append(candidates, homebin)
 	}
 
 	// Finally /usr/bin
 	candidates = append(candidates, "/usr/bin")
-
 	// Test if it makes sense to install to any of those
 	for _, dir := range candidates {
 		if canWrite(dir) && isInPath(dir) {

--- a/install.go
+++ b/install.go
@@ -291,13 +291,7 @@ func findGoodInstallDir() (string, error) {
 	// The first ones have more priority than the last ones
 	var candidates []string
 
-	// First candidate GOBIN
-	gobin := os.Getenv("GOBIN")
-	if gobin != "" {
-		candidates = append(candidates, gobin)
-	}
-
-	// Second candidates, GOPATH(s)/bin
+	// GOPATH(s)/bin
 	gopath := os.Getenv("GOPATH")
 	if gopath != "" {
 		gopaths := strings.Split(gopath, ":")


### PR DESCRIPTION
This was broken for me. My GOPATH includes "$HOME/go/bin:/usr/share/go/contrib", the latter being  the place where rpm-packaged Go modules go.

Also, Go uses GOBIN sometimes, so I check that first.

I also addressed the comment in #19 so it eventually fails over to /usr/bin when nothing else works.

A small behaviour change is that now we check that every path is in $PATH, including the GOPATH/bin. I would find very confusing to install something and not being able to run it right away.

Fun fact: running with sudo ends up installing in /usr/bin for me because /usr/local/bin is not in PATH in that case, but this happened before too.

I more or less disagree that this needs to be installed in GOPATH folders at all, but that's another discussion. Tests don't pass, but it's not my fault (same issue in master).  :) I did a reasonable amount of manual testing and seemed fine.