### PR TITLE
Skip installing if it is the same version as already installed

### DIFF
--- a/install.go
+++ b/install.go
@@ -70,6 +70,10 @@ func (i *Install) Run() error {
 
 	if i.CurrentVers == "none" {
 		stump.VLog("no pre-existing ipfs installation found")
+	} else if i.CurrentVers == i.TargetVers {
+		stump.VLog("Target and Current version are the same")
+		i.Succeeded = true
+		return nil
 	}
 
 	err = i.DownloadNewBinary()


### PR DESCRIPTION
this makes it possible to run 'ipfs-update install latest' in a build script without reinstalling the ipfs binary on every run and still keep using the latest release of ipfs