### PR TITLE
Set timeout when creating go-ipfs shell

### DIFF
--- a/util/utils.go
+++ b/util/utils.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
 	api "github.com/ipfs/go-ipfs-api"
 	config "github.com/ipfs/ipfs-update/config"
@@ -154,6 +155,7 @@ func IpfsDir() string {
 
 func HasDaemonRunning() bool {
 	shell := api.NewShell(LocalApiUrl)
+	shell.SetTimeout(1 * time.Second)
 	return shell.IsUp()
 }
 


### PR DESCRIPTION
When checking if local daemon exists, set a timeout for the shell.IsUp()
call, otherwise it'll hang, leading to ipfs-update to never exit after
finishing install if there is no local daemon running.