### PR TITLE
Fix Windows only issues [#32, #39, #46]

### DIFF
--- a/lib/migrations.go
+++ b/lib/migrations.go
@@ -57,7 +57,7 @@ func CheckMigration() error {
 }
 
 func RunMigration(oldv, newv string) error {
-	migrateBin := "fs-repo-migrations"
+	migrateBin := util.OsExeFileName("fs-repo-migrations")
 	stump.VLog("  - checking for migrations binary...")
 	_, err := exec.LookPath(migrateBin)
 	if err != nil {
@@ -103,7 +103,7 @@ func GetMigrations() (string, error) {
 		return "", fmt.Errorf("tempdir: %s", err)
 	}
 
-	out := filepath.Join(dir, migrations)
+	out := filepath.Join(dir, util.OsExeFileName(migrations))
 
 	err = GetBinaryForVersion(migrations, migrations, util.IpfsVersionPath, latest, out)
 	if err != nil {
@@ -132,7 +132,7 @@ func getMigrationsGoGet() (string, error) {
 	stump.VLog("  - success. verifying...")
 
 	// verify we can see the binary now
-	p, err := exec.LookPath("fs-repo-migrations")
+	p, err := exec.LookPath(util.OsExeFileName("fs-repo-migrations"))
 	if err != nil {
 		return "", fmt.Errorf("install succeeded, but failed to find binary afterwards. (%s)", err)
 	}

--- a/main.go
+++ b/main.go
@@ -226,7 +226,8 @@ var cmdFetch = cli.Command{
 			vers = "v" + vers
 		}
 
-		output := "ipfs-" + vers
+		output := util.OsExeFileName("ipfs-" + vers)
+
 		ofl := c.String("output")
 		if ofl != "" {
 			output = ofl

--- a/test-dist/testnew.go
+++ b/test-dist/testnew.go
@@ -1,7 +1,6 @@
 package testdist
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -10,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
@@ -19,7 +19,10 @@ import (
 
 func runCmd(p, bin string, args ...string) (string, error) {
 	cmd := exec.Command(bin, args...)
-	cmd.Env = []string{"IPFS_PATH=" + p}
+	if runtime.GOOS == "windows" {
+		cmd.Env = os.Environ()
+	}
+	cmd.Env = append(cmd.Env, "IPFS_PATH="+p)
 	stump.VLog("  - running: %s", cmd.Args)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
@@ -110,7 +113,10 @@ func StartDaemon(p, bin string) (io.Closer, error) {
 		return nil, err
 	}
 
-	cmd.Env = []string{"IPFS_PATH=" + p}
+	if runtime.GOOS == "windows" {
+		cmd.Env = os.Environ()
+	}
+	cmd.Env = append(cmd.Env, "IPFS_PATH="+p)
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr
 
@@ -279,11 +285,19 @@ func versionMatch(a, b string) bool {
 
 func testFileAdd(tdir, bin string) error {
 	stump.VLog("  - checking that we can add and cat a file")
-	text := "hello world! This node should work"
-	data := bytes.NewBufferString(text)
-	c := exec.Command(bin, "add", "-q", "--progress=false")
-	c.Env = []string{"IPFS_PATH=" + tdir}
-	c.Stdin = data
+	text := []byte("hello world! This node should work")
+	testFile := filepath.Join(tdir, "/test.txt")
+	err := ioutil.WriteFile(testFile, text, 0644)
+	if err != nil {
+		stump.Error("testfileadd could not create test file: %s", err)
+	}
+
+	c := exec.Command(bin, "add", "-q", "--progress=false", testFile)
+	if runtime.GOOS == "windows" {
+		c.Env = os.Environ()
+	}
+	c.Env = append(c.Env, "IPFS_PATH="+tdir)
+
 	out, err := c.CombinedOutput()
 	if err != nil {
 		stump.Error("testfileadd fail: %s", err)
@@ -297,7 +311,7 @@ func testFileAdd(tdir, bin string) error {
 		return err
 	}
 
-	if fiout != text {
+	if fiout != string(text) {
 		return fmt.Errorf("add/cat check failed")
 	}
 
@@ -307,7 +321,10 @@ func testFileAdd(tdir, bin string) error {
 func testRefsList(tdir, bin string) error {
 	stump.VLog("  - checking that file shows up in ipfs refs local")
 	c := exec.Command(bin, "refs", "local")
-	c.Env = []string{"IPFS_PATH=" + tdir}
+	if runtime.GOOS == "windows" {
+		c.Env = os.Environ()
+	}
+	c.Env = append(c.Env, "IPFS_PATH="+tdir)
 	out, err := c.CombinedOutput()
 	if err != nil {
 		stump.Error("testfileadd fail: %s", err)

--- a/util/utils.go
+++ b/util/utils.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -144,6 +145,9 @@ func Move(src, dest string) error {
 
 func IpfsDir() string {
 	def := filepath.Join(os.Getenv("HOME"), ".ipfs")
+	if runtime.GOOS == "windows" {
+		def = filepath.Join(os.Getenv("USERPROFILE"), ".ipfs")
+	}
 
 	ipfs_path := os.Getenv("IPFS_PATH")
 	if ipfs_path != "" {
@@ -161,7 +165,8 @@ func HasDaemonRunning() bool {
 
 func RunCmd(p, bin string, args ...string) (string, error) {
 	cmd := exec.Command(bin, args...)
-	cmd.Env = append(os.Environ(), "IPFS_PATH="+p)
+	cmd.Env = os.Environ()
+	cmd.Env = append(cmd.Env, "IPFS_PATH="+p)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return "", fmt.Errorf("%s: %s", err, string(out))
@@ -197,4 +202,11 @@ func BeforeVersion(check, cur string) bool {
 
 func BoldText(s string) string {
 	return fmt.Sprintf("\033[1m%s\033[0m")
+}
+
+func OsExeFileName(s string) string {
+	if runtime.GOOS == "windows" {
+		return s + ".exe"
+	}
+	return s
 }

--- a/util/utils.go
+++ b/util/utils.go
@@ -225,9 +225,9 @@ func ArrayContainsEnvVar(arr []string, ev string) bool {
 }
 
 func ReplaceEnvVarIfExists(arr []string, ev string, val string) []string {
-	ev_lower := strings.ToLower(ev)
+	evLower := strings.ToLower(ev) + "="
 	for i := len(arr) - 1; i >= 0; i-- {
-		if strings.Index(strings.ToLower(arr[i]), ev_lower) == 0 {
+		if strings.Index(strings.ToLower(arr[i]), evLower) == 0 {
 			arr = append(arr[:i], arr[i+1:]...)
 		}
 	}


### PR DESCRIPTION
Tested on Windows 10 x64 & Ubuntu 16.04.2 x64 using Go v1.8.3.
This exposes a separate issue which occurs on Windows for fs-repo-migration where it tries to rename the current IPFS folder to the same name:

ipfs/fs-repo-migrations#65