### PR TITLE
codegangsta/cli is now urfave/cli

### DIFF
--- a/main.go
+++ b/main.go
@@ -12,7 +12,7 @@ import (
 	lib "github.com/ipfs/ipfs-update/lib"
 	util "github.com/ipfs/ipfs-update/util"
 
-	cli "github.com/codegangsta/cli"
+	cli "github.com/urfave/cli"
 	stump "github.com/whyrusleeping/stump"
 )
 


### PR DESCRIPTION
Looks like there has been a transfer of repo. So, fixed the import.