### PR TITLE
#73 install at default Go path if GOPATH not set.

### DIFF
--- a/lib/install.go
+++ b/lib/install.go
@@ -294,12 +294,19 @@ func findGoodInstallDir() (string, error) {
 	// Gather some candidate locations
 	// The first ones have more priority than the last ones
 	var candidates []string
+	home := os.Getenv("HOME")
 
 	// GOPATH(s)/bin
 	gopath := os.Getenv("GOPATH")
+
+	// if GOPATH is not set, use the default path $USER/go
+	if gopath == "" && home != "" {
+		gopath = filepath.Join(home, "go")
+	}
+
 	if gopath != "" {
-		gopaths := strings.Split(gopath, ":")
-		for i, _ := range gopaths {
+		gopaths := strings.Split(gopath, string(filepath.ListSeparator))
+		for i := range gopaths {
 			gopaths[i] = filepath.Join(gopaths[i], "bin")
 		}
 		candidates = append(candidates, gopaths...)
@@ -309,7 +316,7 @@ func findGoodInstallDir() (string, error) {
 
 	// Let's try user's $HOME/bin too
 	// but not root because no one installs to /root/bin
-	if home := os.Getenv("HOME"); home != "" && os.Getenv("USER") != "root" {
+	if home != "" && os.Getenv("USER") != "root" {
 		homebin := filepath.Join(home, "bin")
 		candidates = append(candidates, homebin)
 	}

--- a/lib/install.go
+++ b/lib/install.go
@@ -294,25 +294,18 @@ func findGoodInstallDir() (string, error) {
 	// Gather some candidate locations
 	// The first ones have more priority than the last ones
 	var candidates []string
-	home := os.Getenv("HOME")
 
 	// GOPATH(s)/bin
-	gopath := os.Getenv("GOPATH")
+	gopaths := goPaths()
 
-	// if GOPATH is not set, use the default path $USER/go
-	if gopath == "" && home != "" {
-		gopath = filepath.Join(home, "go")
+	for i := range gopaths {
+		gopaths[i] = filepath.Join(gopaths[i], "bin")
 	}
-
-	if gopath != "" {
-		gopaths := strings.Split(gopath, string(filepath.ListSeparator))
-		for i := range gopaths {
-			gopaths[i] = filepath.Join(gopaths[i], "bin")
-		}
-		candidates = append(candidates, gopaths...)
-	}
+	candidates = append(candidates, gopaths...)
 
 	candidates = append(candidates, "/usr/local/bin")
+
+	home := os.Getenv("HOME")
 
 	// Let's try user's $HOME/bin too
 	// but not root because no one installs to /root/bin
@@ -371,4 +364,19 @@ func canWrite(dir string) bool {
 	fi.Close()
 	_ = os.Remove(fi.Name())
 	return true
+}
+
+// goPaths returns one or more Go paths.
+// If GOPATH is not set, $USER/go (the default GOPATH) is returned.
+func goPaths() []string {
+	path := os.Getenv("GOPATH")
+	if path == "" {
+		home := os.Getenv("HOME")
+		if home == "" {
+			panic("Cannot find either the GOPATH or HOME environment variables, please set at least one of them.")
+		}
+		// use the default GOPATH: $HOME/go
+		path = filepath.Join(home, "go")
+	}
+	return strings.Split(path, string(filepath.ListSeparator))
 }

--- a/lib/install.go
+++ b/lib/install.go
@@ -366,14 +366,14 @@ func canWrite(dir string) bool {
 	return true
 }
 
-// goPaths returns one or more Go paths.
-// If GOPATH is not set, $USER/go (the default GOPATH) is returned.
+// goPaths returns all Go paths (may be none if user does not set either GOPATH or HOME).
+// If GOPATH is not set, $USER/go (the default GOPATH) may be returned if $HOME is set.
 func goPaths() []string {
 	path := os.Getenv("GOPATH")
 	if path == "" {
 		home := os.Getenv("HOME")
 		if home == "" {
-			panic("Cannot find either the GOPATH or HOME environment variables, please set at least one of them.")
+			return make([]string, 0)
 		}
 		// use the default GOPATH: $HOME/go
 		path = filepath.Join(home, "go")

--- a/lib/migrations.go
+++ b/lib/migrations.go
@@ -132,11 +132,7 @@ func getMigrationsGoGet() (string, error) {
 	stump.VLog("  - success. verifying...")
 
 	// verify we can see the binary now
-<<<<<<< 97767caccc5a1863843340c04c52c18fd39ed596
-	p, err := exec.LookPath(util.OsExeFileName("fs-repo-migrations"))
-=======
-	migrationsPath, err := exec.LookPath(migrations)
->>>>>>> migrations does not need to know gopath.
+	migrationsPath, err := exec.LookPath(util.OsExeFileName(migrations))
 	if err != nil {
 		return "", fmt.Errorf("install succeeded, but failed to find binary afterwards. (%s)", err)
 	}

--- a/lib/migrations.go
+++ b/lib/migrations.go
@@ -124,7 +124,7 @@ func GetMigrations() (string, error) {
 
 func getMigrationsGoGet() (string, error) {
 	stump.VLog("  - fetching migrations using 'go get'")
-	cmd := exec.Command("go", "get", "-u", "github.com/ipfs/fs-repo-migrations")
+	cmd := exec.Command("go", "get", "-u", "github.com/ipfs/"+migrations)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return "", fmt.Errorf("%s %s", string(out), err)
@@ -132,13 +132,17 @@ func getMigrationsGoGet() (string, error) {
 	stump.VLog("  - success. verifying...")
 
 	// verify we can see the binary now
+<<<<<<< 97767caccc5a1863843340c04c52c18fd39ed596
 	p, err := exec.LookPath(util.OsExeFileName("fs-repo-migrations"))
+=======
+	migrationsPath, err := exec.LookPath(migrations)
+>>>>>>> migrations does not need to know gopath.
 	if err != nil {
 		return "", fmt.Errorf("install succeeded, but failed to find binary afterwards. (%s)", err)
 	}
-	stump.VLog("  - fs-repo-migrations now installed at %s", p)
+	stump.VLog("  - %s now installed at %s", migrations, migrationsPath)
 
-	return filepath.Join(goPaths()[0], "bin", migrations), nil
+	return migrationsPath, nil
 }
 
 func verifyMigrationSupportsVersion(fsrbin, v string) (string, error) {

--- a/lib/migrations.go
+++ b/lib/migrations.go
@@ -138,7 +138,7 @@ func getMigrationsGoGet() (string, error) {
 	}
 	stump.VLog("  - fs-repo-migrations now installed at %s", p)
 
-	return filepath.Join(os.Getenv("GOPATH"), "bin", migrations), nil
+	return filepath.Join(goPaths()[0], "bin", migrations), nil
 }
 
 func verifyMigrationSupportsVersion(fsrbin, v string) (string, error) {


### PR DESCRIPTION
When GOPATH is not set, all Go tooling defaults to $USER/go. This directory is now added to the list of candidates for the installation of ipfs-update.

I also fixed a hardcoded filepath-separator - use the OS-specific separator instead.