### PR TITLE
ipfs update upgrade

### DIFF
--- a/main.go
+++ b/main.go
@@ -137,6 +137,34 @@ var cmdInstall = cli.Command{
 	},
 }
 
+var cmdUpgrade = cli.Command{
+	Name:      "upgrade",
+	Usage:     "Upgrade to the latest version of ipfs.",
+	Action: func(c *cli.Context) error {
+		latest, err := lib.GetLatestVersion(util.IpfsVersionPath, "go-ipfs")
+		if err != nil {
+			stump.Fatal("error resolving 'latest': ", err)
+		}
+		vers = latest
+		i, err := lib.NewInstall(util.IpfsVersionPath, vers, c.Bool("no-check"))
+		if err != nil {
+			return err
+		}
+
+		err = i.Run()
+		if err != nil {
+			return err
+		}
+		stump.Log("\nInstallation complete!")
+
+		if util.HasDaemonRunning() {
+			stump.Log("Remember to restart your daemon before continuing.")
+		}
+
+		return nil
+	},
+}
+
 var cmdStash = cli.Command{
 	Name:  "stash",
 	Usage: "stashes copy of currently installed ipfs binary",


### PR DESCRIPTION
This is a command that should upgrade the go-ipfs binary, which is basically the same logic as 

> `ipfs update install latest`

It really isn't "necessary" per sé - but it is a way to make it very obvious (without requiring interaction) what the command should do. 

If accepted, there should be an immediate change here:

https://github.com/ipfs/go-ipfs/blob/3cc4658af149219b044cd88bc4fab5011896e33f/misc/completion/ipfs-completion.bash#L819

`        _ipfs_comp "upgrade versions version install stash revert fetch"`
