### PR TITLE
Fix Windows install path options

### DIFF
--- a/lib/install.go
+++ b/lib/install.go
@@ -203,7 +203,7 @@ func StashOldBinary(tag string, keep bool) (string, error) {
 	// write the old path of the binary to the backup dir
 	err = ioutil.WriteFile(pathpath, []byte(loc), 0644)
 	if err != nil {
-		return "", fmt.Errorf("couldnt stash path: %s", err)
+		return "", fmt.Errorf("could not stash path: %s", err)
 	}
 
 	f := util.Move

--- a/lib/install.go
+++ b/lib/install.go
@@ -184,6 +184,10 @@ func StashOldBinary(tag string, keep bool) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("could not find old binary: %s", err)
 	}
+	loc, err = filepath.Abs(loc)
+	if err != nil {
+		return "", fmt.Errorf("could not determine absolute path for old binary: %s", err)
+	}
 
 	ipfsdir := util.IpfsDir()
 
@@ -298,44 +302,44 @@ func findGoodInstallDir() (string, error) {
 	// GOPATH(s)/bin
 	gopath := os.Getenv("GOPATH")
 	if gopath != "" {
-		gopaths := strings.Split(gopath, ":")
+		gopaths := strings.Split(gopath, string(os.PathListSeparator))
 		for i, _ := range gopaths {
 			gopaths[i] = filepath.Join(gopaths[i], "bin")
 		}
 		candidates = append(candidates, gopaths...)
 	}
 
-	candidates = append(candidates, "/usr/local/bin")
-
-	// Let's try user's $HOME/bin too
-	// but not root because no one installs to /root/bin
-	if home := os.Getenv("HOME"); home != "" && os.Getenv("USER") != "root" {
-		homebin := filepath.Join(home, "bin")
-		candidates = append(candidates, homebin)
-	}
-
 	if runtime.GOOS == "windows" {
-		// Profile specific, Go devs would normally have this set
-		if profile := os.Getenv("USERPROFILE"); profile != "" {
-			profilebin := filepath.Join(profile, "go", "bin")
-			candidates = append(candidates, profilebin)
+		// Use Go's default bin path if GOPATH is unset
+		if gopath == "" {
+			if profile := os.Getenv("USERPROFILE"); profile != "" {
+				profilebin := filepath.Join(profile, "go", "bin")
+				candidates = append(candidates, profilebin)
+			}
 		}
 
-		// If Go is installed, this should be in PATH
-		if goroot := os.Getenv("GOROOT"); goroot != "" {
-			gorootbin := filepath.Join(goroot, "bin")
-			candidates = append(candidates, gorootbin)
+		cwd, err := os.Getwd()
+		if err == nil {
+			candidates = append(candidates, cwd)
 		}
 
-		// Directory of last resort on Windows, guaranteed to work unless the system is borked
-		if systemroot := os.Getenv("SYSTEMROOT"); systemroot != "" {
-			systemrootbin := filepath.Join(systemroot, "system32")
-			candidates = append(candidates, systemrootbin)
+		ep, err := os.Executable()
+		if err == nil {
+			candidates = append(candidates, filepath.Dir(ep))
 		}
+	} else {
+		candidates = append(candidates, "/usr/local/bin")
+
+		// Let's try user's $HOME/bin too
+		// but not root because no one installs to /root/bin
+		if home := os.Getenv("HOME"); home != "" && os.Getenv("USER") != "root" {
+			homebin := filepath.Join(home, "bin")
+			candidates = append(candidates, homebin)
+		}
+		// Finally /usr/bin
+		candidates = append(candidates, "/usr/bin")
 	}
 
-	// Finally /usr/bin
-	candidates = append(candidates, "/usr/bin")
 	// Test if it makes sense to install to any of those
 	for _, dir := range candidates {
 		if canWrite(dir) && isInPath(dir) {

--- a/util/utils.go
+++ b/util/utils.go
@@ -115,7 +115,7 @@ func newLimitReadCloser(rc io.ReadCloser, limit int64) io.ReadCloser {
 	}
 }
 
-// This function is needed because os.Rename doesnt work across filesystem
+// [2018.06.06] This function is needed because os.Rename doesn't work across filesystem
 // boundaries.
 func CopyTo(src, dest string) error {
 	fi, err := os.Open(src)


### PR DESCRIPTION
Partial fix for https://github.com/ipfs/ipfs-update/issues/86
This changes the install location candidates:
Fixes:
 - Parsing of `%GOPATH%`

Removes (on Windows):
 - non-Windows paths (/usr/local/bin, etc.)
 - System32 (Users should not be putting binaries in here, and likely don't have permission anyway)
 - `%GOROOT%\bin` If there are objections I'll put this one back in, but I think that's reserved for Go's own tools, not user tools.

Adds (on Windows):
 - Current directory
 - Directory which `ipfs-update.exe` was launched from

It also prevents `%GOPATH%\bin` from being added twice on Windows.

Edit:
This patch fixes the issue on its own, but when launched from `go-ipfs` via `ipfs update ...` it encounters issues trying to replace itself. I'm going to look into that issue separately.