### PR TITLE
Handle updating self on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,12 @@
       "hash": "Qmc1AtgBdoUHP8oYSqU81NRYdzohmF45t5XNwVMvhCxsBA",
       "name": "cli",
       "version": "1.19.1"
+    },
+    {
+      "author": "The Go Authors",
+      "hash": "QmPXvegq26x982cQjSfbTvSzZXn7GiaMwhhVPHkeTEhrPT",
+      "name": "sys",
+      "version": "0.1.0"
     }
   ],
   "gxVersion": "0.11.0",

--- a/util/utils.go
+++ b/util/utils.go
@@ -22,6 +22,7 @@ var (
 	GlobalGatewayUrl = "https://ipfs.io"
 	LocalApiUrl      = "http://localhost:5001"
 	IpfsVersionPath  = "/ipns/dist.ipfs.io"
+	removeFallback   func(path string) error
 )
 
 func init() {
@@ -124,6 +125,12 @@ func CopyTo(src, dest string) error {
 	}
 	defer fi.Close()
 
+	if runtime.GOOS == "windows" {
+		if err := removeFallback(dest); err != nil {
+			return fmt.Errorf("copy dest exists and can not be deleted: %s", err)
+		}
+	}
+
 	trgt, err := os.Create(dest)
 	if err != nil {
 		return err
@@ -140,6 +147,12 @@ func Move(src, dest string) error {
 		return err
 	}
 
+	if runtime.GOOS == "windows" {
+		if err := removeFallback(src); err != nil {
+			return fmt.Errorf("move src can not be deleted: %s", err)
+		}
+		return nil
+	}
 	return os.Remove(src)
 }
 

--- a/util/utils_windows.go
+++ b/util/utils_windows.go
@@ -10,7 +10,7 @@ import (
 
 func init() {
 	// attempts to remove path or move it to the systems temporary directory
-	removeFallback = func(path string) error {
+	forceRemove = func(path string) error {
 		if _, err := os.Stat(path); err == nil {
 			if err = os.Remove(path); err != nil {
 				//fallback for when file is still in use (likely the daemon is up)

--- a/util/utils_windows.go
+++ b/util/utils_windows.go
@@ -1,0 +1,25 @@
+package util
+
+import (
+	"os"
+	"path/filepath"
+	"time"
+
+	"golang.org/x/sys/windows"
+)
+
+func init() {
+	// attempts to remove path or move it to the systems temporary directory
+	removeFallback = func(path string) error {
+		if _, err := os.Stat(path); err == nil {
+			if err = os.Remove(path); err != nil {
+				//fallback for when file is still in use (likely the daemon is up)
+				finalpath := filepath.Join(os.TempDir(), time.Now().Format("2006.01.02-15.04.05")+" "+filepath.Base(path))
+				if err = windows.MoveFileEx(windows.StringToUTF16Ptr(path), windows.StringToUTF16Ptr(finalpath), windows.MOVEFILE_COPY_ALLOWED); err != nil {
+					return err
+				}
+			}
+		}
+		return nil
+	}
+}


### PR DESCRIPTION
Followup to: https://github.com/ipfs/ipfs-update/pull/87

This should fix the issue of updating `ipfs.exe` when launched from `ipfs.exe` as well as when it's in use by other processes.
On Windows, we can't delete files that are in use, but we can move them. As a fallback, we try to move it to the system's temporary directory where it can be deleted eventually.
There is a flag that allows us to schedule these files to be deleted on boot, but that flag requires admin rights to succeed, so we leave cleanup to the user / system services.
These discarded files are renamed to contain a timestamp for pseudo-uniqueness to prevent possible conflicts. The name could be changed if desired.

Example: https://ipfs.io/ipfs/zDMZof1m1RDh2XA5Utthu41G1nLNfD5E9uPsDMinp4wmUUVKR2Nr/Desktop%202018.06.07%20-%2015.47.33.13-an.mp4
