### PR TITLE
Update minimum go version to 1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ os:
 language: go
 
 go:
-  - 1.8
+  - "1.10.2"
 
 env:
   - TEST_VERBOSE=1

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 ## Install
 
-Requirement: Go version 1.8 or higher.
+Requirement: Go version 1.10 or higher.
 
 ```sh
 go get -u github.com/ipfs/ipfs-update


### PR DESCRIPTION
Go 1.9 appears to be needed to provide math/bits dependency