### PR TITLE
document "latest" version string in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ Prints out all versions of ipfs available for installation.
 
 `$ ipfs-update install <version>`
 
-Downloads, tests, and installs the specified version
-of ipfs. The existing version is stashed in case a revert is needed.
+Downloads, tests, and installs the specified version (or "latest" for
+latest version) of ipfs. The existing version is stashed in case a revert is needed.
 
 #### revert
 


### PR DESCRIPTION
This (useful!) feature isn't obvious unless you read the godocs or just try it out of habit.

I do wonder if having a "tag" system like nvm/docker would be more robust (so we could have a latest/stable/nightly tag), though it might not be worth reimplementing that yet again in our updater tool.