### PR TITLE
Intelligent install logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,39 @@ Downloads the specified version of ipfs into your current
 directory. This is a plumbing command that can be utilized in scripts or by
 more advanced users.
 
+## Install Location
+
+`ipfs-update` tries to intelligently pick the correct install location for
+go-ipfs.
+
+1. If you have go-ipfs installed, `ipfs-update` will install over your existing install.
+2. If you have a Go development environment setup, it will install go-ipfs along
+   with all of your other go programs.
+3. Otherwise, it will try to pick a sane, writable install location.
+
+Specifically, `ipfs-update` will install go-ipfs according to the following
+algorithm:
+
+0. If `go-ipfs` is already installed and in your PATH, `ipfs-update` will
+   replace it. `ipfs-update` will _fail_ if it can't and won't try to install
+   elsewhere.
+1. If Go is installed:
+  1. [GOBIN][go-env] if GOBIN is in your PATH.
+  2. For each `$path` in GOPATH, `$path/bin` if it's in your PATH.
+2. On Windows:
+  1. The current directory if it's writable and in your PATH.
+  2. The directory where the ipfs-update executable lives if it's executable and in your path.
+3. On all platforms _except_ Windows:
+  1. If root:
+    1. `/usr/local/bin` if it exists, is writable, and is in your PATH.
+    2. `/usr/bin` if it exists, is writable, and is in your PATH.
+  2. `$HOME/.local/bin` if it exists, is writable, and is in your PATH.
+  3. `$HOME/bin` if it exists, is writable, and is in your PATH.
+  4. `$HOME/.local/bin` if we can create it and it's in your PATH.
+  5. `$HOME/bin` if we can create it and it's in your PATH.
+
+[go-env]: https://golang.org/cmd/go/#hdr-Environment_variables
+
 ## Contribute
 
 Feel free to join in. All welcome. Open an [issue](https://github.com/ipfs/ipfs-update/issues)!

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/ipfs/ipfs-update
 go 1.12
 
 require (
+	github.com/coreos/go-semver v0.3.0
 	github.com/ipfs/go-ipfs-api v0.0.2
 	github.com/urfave/cli v1.22.1
 	github.com/whyrusleeping/stump v0.0.0-20160611222256-206f8f13aae1

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,8 @@ github.com/btcsuite/websocket v0.0.0-20150119174127-31079b680792/go.mod h1:ghJtE
 github.com/btcsuite/winsvc v1.0.0/go.mod h1:jsenWakMcC0zFBFurPLEAyrnc/teJEM1O46fmI40EZs=
 github.com/cheekybits/is v0.0.0-20150225183255-68e9c0620927 h1:SKI1/fuSdodxmNNyVBR8d7X/HuLnRpvvFO0AgyQk764=
 github.com/cheekybits/is v0.0.0-20150225183255-68e9c0620927/go.mod h1:h/aW8ynjgkuj+NQRlZcDbAbM1ORAbXjXX77sX7T289U=
+github.com/coreos/go-semver v0.3.0 h1:wkHLiw0WNATZnSG7epLsujiMCgPAc9xhjJ4tgnAxmfM=
+github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d h1:U+s90UTSYgptZMwQh2aRr3LuazLJIa+Pg3Kc1ylSYVY=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/davecgh/go-spew v0.0.0-20171005155431-ecdeabc65495 h1:6IyqGr3fnd0tM3YxipK27TUskaOVUjU2nG45yzwcQKY=


### PR DESCRIPTION
We've had a bunch of PRs like this but I'm hoping this will finally resolve the issue, once and for all (except on Windows because Windows).

The primary changes are:

* Support for ~/.local/bin (the "correct" place to install things on Linux; please don't flame me).
* Uses `go` to find the `GOPATH`.
* Supports `GOBIN`.
* Will create some of these directories as necessary _if_ they already exist in the user's PATH.

fixes #73, #74