### PR TITLE
Advise Windows GUI users semi-automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ algorithm:
 2. On Windows:
   1. The current directory if it's writable and in your PATH.
   2. The directory where the ipfs-update executable lives if it's executable and in your path.
+  3. The directory where the ipfs-update executable lives if it's executable and in your current working directory.
 3. On all platforms _except_ Windows:
   1. If root:
     1. `/usr/local/bin` if it exists, is writable, and is in your PATH.

--- a/lib/install.go
+++ b/lib/install.go
@@ -356,6 +356,14 @@ func findGoodInstallDir() (string, error) {
 			if inPath(dir) && canWrite(dir) {
 				return dir, nil
 			}
+
+			if cwd == dir && canWrite(dir) {
+				_, exeName := filepath.Split(ep)
+				// [2020.01.28] on Windows, the "command search sequence" includes the current directory
+				// while not included in %PATH%, it should be rare that this branch is traversed on accident and is likely expected to succeed on this platform
+				stump.Log("current working directory is not within %%PATH%% variable, but %q exists in cwd; using cwd as install target", exeName)
+				return dir, nil
+			}
 		}
 		return "", errNoGoodInstall
 	}

--- a/util/utils.go
+++ b/util/utils.go
@@ -27,6 +27,8 @@ var (
 	forceRemove = func(path string) error {
 		return os.Remove(path)
 	}
+
+	InsideGUI = func() bool { return false }
 )
 
 func init() {

--- a/util/utils_windows.go
+++ b/util/utils_windows.go
@@ -10,16 +10,18 @@ import (
 
 func init() {
 	// attempts to remove path or move it to the systems temporary directory
-	forceRemove = func(path string) error {
-		if _, err := os.Stat(path); err == nil {
-			if err = os.Remove(path); err != nil {
-				//fallback for when file is still in use (likely the daemon is up)
-				finalpath := filepath.Join(os.TempDir(), time.Now().Format("2006.01.02-15.04.05")+" "+filepath.Base(path))
-				if err = windows.MoveFileEx(windows.StringToUTF16Ptr(path), windows.StringToUTF16Ptr(finalpath), windows.MOVEFILE_COPY_ALLOWED); err != nil {
-					return err
-				}
+	forceRemove = winForceRemove
+}
+
+func winForceRemove(path string) error {
+	if _, err := os.Stat(path); err == nil {
+		if err = os.Remove(path); err != nil {
+			// fallback for when file is still in use (likely the daemon is up)
+			finalpath := filepath.Join(os.TempDir(), time.Now().Format("2006.01.02-15.04.05")+" "+filepath.Base(path))
+			if err = windows.MoveFileEx(windows.StringToUTF16Ptr(path), windows.StringToUTF16Ptr(finalpath), windows.MOVEFILE_COPY_ALLOWED); err != nil {
+				return err
 			}
 		}
-		return nil
 	}
+	return nil
 }

--- a/util/utils_windows.go
+++ b/util/utils_windows.go
@@ -11,6 +11,7 @@ import (
 func init() {
 	// attempts to remove path or move it to the systems temporary directory
 	forceRemove = winForceRemove
+	InsideGUI = winInsideGUI
 }
 
 func winForceRemove(path string) error {
@@ -24,4 +25,18 @@ func winForceRemove(path string) error {
 		}
 	}
 	return nil
+}
+func winInsideGUI() bool {
+	conhostInfo := &windows.ConsoleScreenBufferInfo{}
+	if err := windows.GetConsoleScreenBufferInfo(windows.Stdout, conhostInfo); err != nil {
+		return false
+	}
+
+	if (conhostInfo.CursorPosition.X | conhostInfo.CursorPosition.Y) == 0 {
+		// console cursor has not moved prior to our execution
+		// high probability that we're not in a terminal
+		return true
+	}
+
+	return false
 }


### PR DESCRIPTION
An approach to resolve https://github.com/ipfs/ipfs-update/issues/108
When launched from a GUI environment, we inform the user what's up and offer to help them out via video. Otherwise, it's business as usual.
![thing](https://user-images.githubusercontent.com/13862850/73262346-ecfd9700-419b-11ea-94aa-e7aca854adc5.png)

[Demo](https://www.youtube.com/watch?v=NxcV22Owsrc)
[Target video](https://youtu.be/UCQTSszdVmQ)

This is more than was asked for in the original issue, if it's too fancy we can easily change the patchset to do the original request only.

Also changes behaviour of `install` on Windows to allow for installing to cwd if we're within it.
And suggests `go get -u` instead of `go get` in the README
Both of these are droppable, but the demo will need to change to account for it.

Edit: now with less typos
https://github.com/ipfs/ipfs-update/compare/1d45084a09213f490d0b23488dc9efc166844760..c29c95afa9166321c30e7e99405884115fbcad9e