### PR TITLE
fix: fix ipfs api detection

### DIFF
--- a/lib/versions.go
+++ b/lib/versions.go
@@ -52,7 +52,8 @@ func GetCurrentVersion() (string, error) {
 	apiurl, err := util.ApiEndpoint(util.IpfsDir())
 	if err == nil {
 		sh := api.NewShell(apiurl)
-		v, _, err := sh.Version()
+		var v string
+		v, _, err = sh.Version()
 		if err == nil {
 			return fix(v), nil
 		}

--- a/util/utils.go
+++ b/util/utils.go
@@ -42,14 +42,16 @@ const fetchSizeLimit = 1024 * 1024 * 512
 func ApiEndpoint(ipfspath string) (string, error) {
 	apifile := filepath.Join(ipfspath, "api")
 
-	val, err := ioutil.ReadFile(apifile)
+	valbytes, err := ioutil.ReadFile(apifile)
 	if err != nil {
 		return "", err
 	}
 
-	parts := strings.Split(string(val), "/")
+	val := strings.TrimSpace(string(valbytes))
+
+	parts := strings.Split(val, "/")
 	if len(parts) != 5 {
-		return "", fmt.Errorf("incorrectly formatted api string: %q", string(val))
+		return "", fmt.Errorf("incorrectly formatted api string: %q", val)
 	}
 
 	return parts[2] + ":" + parts[4], nil


### PR DESCRIPTION
1. Strip trailing newlines from the API addr file (in case the user wrote it themselves).
2. Avoid throwing away the error if contacting the API fails.