### PR TITLE
ci: upgrade go to 1.16 and 1.17 in sharness workflow

### DIFF
--- a/.github/workflows/sharness.yml
+++ b/.github/workflows/sharness.yml
@@ -5,7 +5,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: [ "1.15.x", "1.16.x" ]
+        go: [ "1.16.x", "1.17.x" ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
As we're upgrading other workflows to go 1.16 and 1.17 here (https://github.com/ipfs/ipfs-update/pull/147), I think we should probably upgrade the versions in sharness workflow. 