### PR TITLE
chore: switch to kubo and .tech tld

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -7,7 +7,7 @@ labels: bug
 #### Version information:
 <!-- Output From `ipfs-update --version`
 
-Please check dist.ipfs.io for a newer version of ipfs-update and update if necessary. Report back if the problem persists.
+Please check dist.ipfs.tech for a newer version of ipfs-update and update if necessary. Report back if the problem persists.
 -->
 
 #### Description:

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # ipfs-update
 
-> An updater tool for ipfs. Can fetch and install given versions of go-ipfs.
+> An updater tool for ipfs. Can fetch and install given versions of Kubo.
 
 [![](https://img.shields.io/badge/made%20by-Protocol%20Labs-blue.svg?style=flat-square)](http://ipn.io)
-[![](https://img.shields.io/badge/project-IPFS-blue.svg?style=flat-square)](http://ipfs.io/)
+[![](https://img.shields.io/badge/project-IPFS-blue.svg?style=flat-square)](http://ipfs.tech/)
 [![](https://img.shields.io/badge/freenode-%23ipfs-blue.svg?style=flat-square)](http://webchat.freenode.net/?channels=%23ipfs)
 [![Travis CI](https://travis-ci.org/ipfs/ipfs-update.svg?branch=master)](https://travis-ci.org/ipfs/ipfs-update)
 [![standard-readme compliant](https://img.shields.io/badge/standard--readme-OK-green.svg?style=flat-square)](https://github.com/RichardLitt/standard-readme)
@@ -14,7 +14,7 @@ You can either install a pre-built binary or build `ipfs-update` from source.
 
 ### Pre-built Binaries
 
-You can download pre-built binaries at: https://dist.ipfs.io/#ipfs-update
+You can download pre-built binaries at: https://dist.ipfs.tech/#ipfs-update
 
 ### From Source
 
@@ -73,17 +73,17 @@ more advanced users.
 ## Install Location
 
 `ipfs-update` tries to intelligently pick the correct install location for
-go-ipfs.
+Kubo.
 
-1. If you have go-ipfs installed, `ipfs-update` will install over your existing install.
-2. If you have a Go development environment setup, it will install go-ipfs along
+1. If you have Kubo (`ipfs`) installed, `ipfs-update` will install over your existing install.
+2. If you have a Go development environment setup, it will install Kubo along
    with all of your other go programs.
 3. Otherwise, it will try to pick a sane, writable install location.
 
-Specifically, `ipfs-update` will install go-ipfs according to the following
+Specifically, `ipfs-update` will install Kubo according to the following
 algorithm:
 
-0. If `go-ipfs` is already installed and in your PATH, `ipfs-update` will
+0. If Kubo (`ipfs`) is already installed and in your PATH, `ipfs-update` will
    replace it. `ipfs-update` will _fail_ if it can't and won't try to install
    elsewhere.
 1. If Go is installed:
@@ -106,7 +106,7 @@ algorithm:
 
 ## Custom IPFS gateway URL
 
-By default, `ipfs-update` uses https://ipfs.io as the gateway URL. If you wish to use your own IPFS gateway URL, please export it via the environment variable `IPFS_CUSTOM_GATEWAY_URL`.
+By default, `ipfs-update` uses https://ipfs.io as the gateway URL. If you wish to use your own IPFS gateway URL, please export it via the environment variable `IPFS_GATEWAY`.
 
 For example:
 

--- a/lib/install.go
+++ b/lib/install.go
@@ -244,6 +244,7 @@ func (i *Install) downloadNewBinary(ctx context.Context) error {
 		return err
 	}
 
+	// TODO: switch to "kubo" distname after 1+ year since rename in 2022 ;-)
 	distname := "go-ipfs"
 	stump.Log("fetching %s version %s", distname, i.targetVers)
 

--- a/sharness/t0040-install-many.sh
+++ b/sharness/t0040-install-many.sh
@@ -30,7 +30,7 @@ test_expect_success ".ipfs/ has been created" '
 	exec_docker "$DOCID" "test -d  /root/.ipfs/datastore && test -d /root/.ipfs/blocks"
 '
 
-latest_version=$(curl -s https://dist.ipfs.io/go-ipfs/versions | tail -n 1)
+latest_version=$(curl -s https://dist.ipfs.tech/kubo/versions | tail -n 1)
 test_install_version "$latest_version"
 
 test_expect_success "stop a docker container" '


### PR DESCRIPTION
> Part of https://github.com/protocol/bifrost-infra/issues/2018 and https://github.com/ipfs/go-ipfs/issues/8959

# TODO

- [x] README
- [ ] <del>make sure binaries are fetched from .tech</del>
  - This will be applied in a separate PR, after Kubo 0.15+ ships with https://github.com/ipfs/kubo/pull/9190  